### PR TITLE
React17 dangerously set inner html

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,7 +14,7 @@ const Icon = forwardRef<SVGSVGElement, IconProps>(({ src, ...props }, ref) => (
     aria-hidden="true"
     {...props}
     ref={ref}
-    dangerouslySetInnerHtml={iconMap[src]}
+    dangerouslySetInnerHTML={{__html: iconMap[src]}}
   />
 ));
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,9 +14,8 @@ const Icon = forwardRef<SVGSVGElement, IconProps>(({ src, ...props }, ref) => (
     aria-hidden="true"
     {...props}
     ref={ref}
-  >
-    {iconMap[src]}
-  </svg>
+    dangerouslySetInnerHtml={iconMap[src]}
+  />
 ));
 
 export default Icon;


### PR DESCRIPTION
After update to react 17.0.1 the output of the inner svg was a string. My suggestion is to use setDangerouslyInnerHtml to parse 